### PR TITLE
Fixes pinned make for Ubuntu 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+SHELL=/bin/bash
+
 # set -x
 # set -e
 


### PR DESCRIPTION
Pinning to the current master branch in Ubuntu gives the attached error output and fails to build. This (thanks to @kayceesrk) resolves the problem.

```
dev@matt-project:~$ opam pin add macaroons -kgit https://github.com/nojb/ocaml-macaroons
[NOTE] macaroons is currently http-pinned to
       https://github.com/m-harrison/ocaml-macaroons/tree/ubuntu-make-fix.
Proceed ? [Y/n] Y
macaroons is now git-pinned to https://github.com/nojb/ocaml-macaroons

[macaroons] https://github.com/nojb/ocaml-macaroons updated
[macaroons] Installing new package description from https://github.com/nojb/ocaml-macaroons

macaroons needs to be installed.
The following actions will be performed:
  ∗  install macaroons 0.1.0*
Do you want to continue ? [Y/n] Y

=-=- Gathering sources =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
[macaroons] https://github.com/nojb/ocaml-macaroons already up-to-date

=-=- Processing actions -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
[ERROR] The compilation of macaroons failed at "make".
Processing  1/1: [macaroons: ocamlfind remove]
#=== ERROR while installing macaroons.0.1.0 ===================================#
# opam-version 1.2.2
# os           linux
# command      make
# path         /home/dev/.opam/4.03.0/build/macaroons.0.1.0
# compiler     4.03.0
# exit-code    2
# env-file     /home/dev/.opam/4.03.0/build/macaroons.0.1.0/macaroons-29749-d8a4ae.env
# stdout-file  /home/dev/.opam/4.03.0/build/macaroons.0.1.0/macaroons-29749-d8a4ae.out
# stderr-file  /home/dev/.opam/4.03.0/build/macaroons.0.1.0/macaroons-29749-d8a4ae.err
### stdout ###
# ocamlbuild -use-ocamlfind -classic-display lib/macaroons.{cma,cmxa,cmxs,a}
# Solver failed:
#   Ocamlbuild knows of no rules that apply to a target named lib/macaroons.{cma,cmxa,cmxs,a}. This can happen if you ask Ocamlbuild to build a target with the wrong extension (e.g. .opt instead of .native) or if the source files live in directories that have not been specified as include directories.
# Backtrace:
#   - Failed to build the target lib/macaroons.{cma,cmxa,cmxs,a}
#       - Building lib/macaroons.{cma,cmxa,cmxs,a}
# Makefile:12: recipe for target 'build' failed
### stderr ###
# make: *** [build] Error 6



=-=- Error report -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
The following actions failed
  ∗  install macaroons 0.1.0
No changes have been performed
[NOTE] Pinning command successful, but your installed packages may be out of sync.
```